### PR TITLE
Added TriP

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ to successfully design systems architecture.
 ## Sensor Processing
 ### Calibration and Transformation
 * [tf2](http://wiki.ros.org/tf2) - Transform library, which lets the user keep track of multiple coordinate frames over time.
+* [TriP](https://github.com/TriPed-Robot/TriP) - A Inverse Kinematics library for serial robots, parallel robots and hybrids of both.
 * [lidar_align](https://github.com/ethz-asl/lidar_align) - A simple method for finding the extrinsic calibration between a 3D lidar and a 6-dof pose sensor.
 * [kalibr](https://github.com/ethz-asl/kalibr) - The Kalibr visual-inertial calibration toolbox.
 * [Calibnet](https://github.com/epiception/CalibNet) - Self-Supervised Extrinsic Calibration using 3D Spatial Transformer Networks.


### PR DESCRIPTION
While a huge number of researchers use hybrid serial parallel systems most modern kinematics frameworks still lack support. Examples include openrave used in the moveit stack  or the matlab robotics toolbox which only support inverse kinematics for serial mechanisms.​This lack of support often leaves developers with essentially two choices:

Either shoehorn their hybrid robots into a framework not designed to handle them or be left to implement their own kinematic solvers.

​TriP is a lightweight and easy-to-use package directly modeling hybrid mechanisms and calculating their inverse and forward kinematics.